### PR TITLE
Fix picker UX: cleanup, type dedup, and behavior improvements

### DIFF
--- a/src/date-picker.ts
+++ b/src/date-picker.ts
@@ -279,7 +279,6 @@ export class DatePicker extends LitElement {
   }
 
   public open(input: HTMLInputElement) {
-    console.log("open");
     this.targetInput = input;
     this.isOpen = true;
 
@@ -297,20 +296,15 @@ export class DatePicker extends LitElement {
       this.lastValidDate = null;
     }
 
-    console.log("open2");
     this.updatePickerPosition(input);
     this.addDocumentClickHandler();
   }
 
   private updatePickerPosition(input: HTMLInputElement) {
-    console.log("updatePickerPosition");
     const rect = input.getBoundingClientRect();
     const picker = this.shadowRoot?.querySelector(
       ".picker-container"
     ) as HTMLElement;
-    console.log("updatePickerPosition2");
-    // .picker-containerがなさそう。
-    console.log(picker);
     if (!picker) return;
 
     const viewportHeight = window.innerHeight;

--- a/src/date-picker.ts
+++ b/src/date-picker.ts
@@ -81,7 +81,7 @@ export class DatePicker extends LitElement {
     }
 
     .picker-container {
-      position: fixed;
+      position: absolute;
       z-index: 1000;
       background: var(--dt-background, white);
       border: 1px solid var(--dt-border-color, #e5e7eb);
@@ -196,6 +196,9 @@ export class DatePicker extends LitElement {
   @property({ type: String })
   locale = "ja";
 
+  @property({ type: Boolean })
+  disabled = false;
+
   @state()
   private year: number = new Date().getFullYear();
 
@@ -222,6 +225,9 @@ export class DatePicker extends LitElement {
   > = new Map();
 
   private boundHandleDocumentClick = this.handleDocumentClick.bind(this);
+  private boundHandleKeydown = this.handleKeydown.bind(this);
+  private boundHandleResize = this.handleResize.bind(this);
+  private resizeRafId = 0;
 
   connectedCallback() {
     super.connectedCallback();
@@ -231,6 +237,9 @@ export class DatePicker extends LitElement {
   disconnectedCallback() {
     super.disconnectedCallback();
     this.removeDocumentClickHandler();
+    document.removeEventListener("keydown", this.boundHandleKeydown);
+    window.removeEventListener("resize", this.boundHandleResize);
+    cancelAnimationFrame(this.resizeRafId);
     this.cleanupInputElements();
   }
 
@@ -279,6 +288,10 @@ export class DatePicker extends LitElement {
   }
 
   public open(input: HTMLInputElement) {
+    if (this.disabled) return;
+    if (this.isOpen && input === this.targetInput) return;
+    if (this.isOpen) this.close();
+
     this.targetInput = input;
     this.isOpen = true;
 
@@ -298,6 +311,8 @@ export class DatePicker extends LitElement {
 
     this.updatePickerPosition(input);
     this.addDocumentClickHandler();
+    document.addEventListener("keydown", this.boundHandleKeydown);
+    window.addEventListener("resize", this.boundHandleResize);
   }
 
   private updatePickerPosition(input: HTMLInputElement) {
@@ -308,13 +323,25 @@ export class DatePicker extends LitElement {
     if (!picker) return;
 
     const viewportHeight = window.innerHeight;
+    const viewportWidth = window.innerWidth;
     const pickerHeight = picker.offsetHeight;
+    const pickerWidth = picker.offsetWidth;
 
-    picker.style.left = `${rect.left}px`;
+    // 横位置: 左右はみ出し対応
+    let left = rect.left + window.scrollX;
+    if (rect.left + pickerWidth > viewportWidth) {
+      left = rect.right + window.scrollX - pickerWidth;
+    }
+    if (left < window.scrollX) {
+      left = window.scrollX;
+    }
+    picker.style.left = `${left}px`;
+
+    // 縦位置: 下方向に収まらない場合は上方向に配置
     if (rect.bottom + pickerHeight > viewportHeight) {
-      picker.style.top = `${rect.top - pickerHeight - 8}px`;
+      picker.style.top = `${rect.top + window.scrollY - pickerHeight - 8}px`;
     } else {
-      picker.style.top = `${rect.bottom + 8}px`;
+      picker.style.top = `${rect.bottom + window.scrollY + 8}px`;
     }
   }
 
@@ -439,6 +466,24 @@ export class DatePicker extends LitElement {
   private close() {
     this.isOpen = false;
     this.removeDocumentClickHandler();
+    document.removeEventListener("keydown", this.boundHandleKeydown);
+    window.removeEventListener("resize", this.boundHandleResize);
+    cancelAnimationFrame(this.resizeRafId);
+  }
+
+  private handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") {
+      this.close();
+    }
+  }
+
+  private handleResize() {
+    cancelAnimationFrame(this.resizeRafId);
+    this.resizeRafId = requestAnimationFrame(() => {
+      if (this.targetInput) {
+        this.updatePickerPosition(this.targetInput);
+      }
+    });
   }
 
   private isToday(date: number): boolean {

--- a/src/datetime-picker.ts
+++ b/src/datetime-picker.ts
@@ -157,6 +157,9 @@ export class DatetimePicker extends LitElement {
   @state() private isOpen = false;
   @state() private isEditing = false;
   private boundHandleDocumentClick: (e: MouseEvent) => void;
+  private boundHandleKeydown: (e: KeyboardEvent) => void;
+  private boundHandleResize: () => void;
+  private resizeRafId = 0;
   private targetInput: HTMLInputElement | null = null;
   private inputEventListeners: Map<
     HTMLInputElement,
@@ -184,6 +187,8 @@ export class DatetimePicker extends LitElement {
     this.lastValidDateTime = null;
     this.currentInputValue = "";
     this.boundHandleDocumentClick = this.handleDocumentClick.bind(this);
+    this.boundHandleKeydown = this.handleKeydown.bind(this);
+    this.boundHandleResize = this.handleResize.bind(this);
   }
 
   // ----------------------------------------
@@ -194,7 +199,7 @@ export class DatetimePicker extends LitElement {
       display: contents;
     }
     .picker-container {
-      position: fixed;
+      position: absolute;
       z-index: 9999;
       background: var(--dt-background, white);
       border-radius: var(--dt-border-radius, 0.5rem);
@@ -406,6 +411,9 @@ export class DatetimePicker extends LitElement {
   disconnectedCallback() {
     super.disconnectedCallback();
     this.removeDocumentClickHandler();
+    document.removeEventListener("keydown", this.boundHandleKeydown);
+    window.removeEventListener("resize", this.boundHandleResize);
+    cancelAnimationFrame(this.resizeRafId);
     this.cleanupInputElements();
   }
 
@@ -460,6 +468,10 @@ export class DatetimePicker extends LitElement {
   }
 
   public open(input: HTMLInputElement) {
+    if (this.disabled) return;
+    if (this.isOpen && input === this.targetInput) return;
+    if (this.isOpen) this.closePicker();
+
     this.targetInput = input;
     this.isOpen = true;
 
@@ -485,6 +497,8 @@ export class DatetimePicker extends LitElement {
 
     this.updatePickerPosition(input);
     this.addDocumentClickHandler();
+    document.addEventListener("keydown", this.boundHandleKeydown);
+    window.addEventListener("resize", this.boundHandleResize);
   }
 
   private updatePickerPosition(input: HTMLInputElement) {
@@ -495,13 +509,25 @@ export class DatetimePicker extends LitElement {
     if (!picker) return;
 
     const viewportHeight = window.innerHeight;
+    const viewportWidth = window.innerWidth;
     const pickerHeight = picker.offsetHeight;
+    const pickerWidth = picker.offsetWidth;
 
-    picker.style.left = `${rect.left}px`;
+    // 横位置: 左右はみ出し対応
+    let left = rect.left + window.scrollX;
+    if (rect.left + pickerWidth > viewportWidth) {
+      left = rect.right + window.scrollX - pickerWidth;
+    }
+    if (left < window.scrollX) {
+      left = window.scrollX;
+    }
+    picker.style.left = `${left}px`;
+
+    // 縦位置: 下方向に収まらない場合は上方向に配置
     if (rect.bottom + pickerHeight > viewportHeight) {
-      picker.style.top = `${rect.top - pickerHeight - 8}px`;
+      picker.style.top = `${rect.top + window.scrollY - pickerHeight - 8}px`;
     } else {
-      picker.style.top = `${rect.bottom + 8}px`;
+      picker.style.top = `${rect.bottom + window.scrollY + 8}px`;
     }
   }
 
@@ -611,11 +637,29 @@ export class DatetimePicker extends LitElement {
   private closePicker() {
     this.isOpen = false;
     this.removeDocumentClickHandler();
+    document.removeEventListener("keydown", this.boundHandleKeydown);
+    window.removeEventListener("resize", this.boundHandleResize);
+    cancelAnimationFrame(this.resizeRafId);
     // ピッカーを閉じる時に選択状態をリセット
     this.selectedDate = undefined;
     this.selectedHour = undefined;
     this.selectedMinute = undefined;
     this.targetInput = null;
+  }
+
+  private handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") {
+      this.closePicker();
+    }
+  }
+
+  private handleResize() {
+    cancelAnimationFrame(this.resizeRafId);
+    this.resizeRafId = requestAnimationFrame(() => {
+      if (this.targetInput) {
+        this.updatePickerPosition(this.targetInput);
+      }
+    });
   }
 
   // ----------------------------------------

--- a/src/datetime-picker.ts
+++ b/src/datetime-picker.ts
@@ -1,12 +1,6 @@
 import { LitElement, css, html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-export interface DateTimeState {
-  year: number | null;
-  month: number | null;
-  date: number | null;
-  hour: number | null;
-  minute: number | null;
-}
+import { DateTimeState } from "./types";
 
 export interface DateTimeChangeEvent extends CustomEvent {
   detail: {

--- a/src/datetime-picker.ts
+++ b/src/datetime-picker.ts
@@ -419,7 +419,6 @@ export class DatetimePicker extends LitElement {
     for (const input of document.querySelectorAll(
       "input[data-recomped-datetime-picker]"
     )) {
-      console.log(input);
       if (input instanceof HTMLInputElement) {
         this.setupInput(input);
       }
@@ -500,8 +499,6 @@ export class DatetimePicker extends LitElement {
       ".picker-container"
     ) as HTMLElement;
     if (!picker) return;
-
-    console.log(picker);
 
     const viewportHeight = window.innerHeight;
     const pickerHeight = picker.offsetHeight;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import { DatePicker, initDatePicker } from "./date-picker";
 import { DatetimePicker, initDatetimePicker } from "./datetime-picker";
 export { DatetimePicker, initDatetimePicker, DatePicker, initDatePicker };
-export type { DateTimeState, DateTimeChangeEvent } from "./datetime-picker";
+export type { DateTimeState } from "./types";
+export type { DateTimeChangeEvent } from "./datetime-picker";
 export type { DateState, DateChangeEvent } from "./date-picker";
 
 // Get the singleton instances


### PR DESCRIPTION
  ## Summary

  - DatePicker / DatetimePicker の debug 用 console.log を全削除
  - `DateTimeState` の重複定義を解消（`types.ts` から import に統一）
  - `disabled` プロパティが `open()` で参照されていなかった問題を修正
  - ビューポート端でピッカーがはみ出す問題を修正（左右両対応）
  - Escape キーでピッカーを閉じる機能を追加
  - `position: fixed` → `position: absolute` + `scrollX/scrollY` でスクロール追従
  - ウィンドウリサイズ時に `requestAnimationFrame` で位置を再計算
  - ピッカー表示中に別の input にフォーカスした際、ターゲットを切り替えて再表示

  ## Key Changes

  - `src/datetime-picker.ts`: console.log 削除、DateTimeState import 化、open()/closePicker()/updatePickerPosition() 改修、handleKeydown/handleResize 追加
  - `src/date-picker.ts`: console.log 削除、disabled プロパティ追加、open()/close()/updatePickerPosition() 改修、handleKeydown/handleResize 追加
  - `src/index.ts`: DateTimeState の re-export パスを types.ts に変更
